### PR TITLE
prevent setting message attributes by reference in dbc parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .DS_Store
 .vscode
 dist-bundle
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "candied",
       "version": "2.1.0",
       "license": "ISC",
+      "dependencies": {
+        "candied": "^2.1.0"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -1926,6 +1929,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/candied": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/candied/-/candied-2.1.0.tgz",
+      "integrity": "sha512-z+xcyVDWyIyEyPFh1A+lycqlkoXMIursTXOmTBGQrG3Wd4tYD+Sy1o7qlGtw8y6ed+wkKHnbuBu96dGa3mZRkg=="
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001374",
@@ -6977,6 +6985,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "candied": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/candied/-/candied-2.1.0.tgz",
+      "integrity": "sha512-z+xcyVDWyIyEyPFh1A+lycqlkoXMIursTXOmTBGQrG3Wd4tYD+Sy1o7qlGtw8y6ed+wkKHnbuBu96dGa3mZRkg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001374",

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "tslint-config-prettier": "^1.18.0",
     "tspeg": "^3.2.1",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "candied": "^2.1.0"
   }
 }

--- a/src/__tests__/attributes.test.ts
+++ b/src/__tests__/attributes.test.ts
@@ -41,6 +41,26 @@ test('DBC_template.dbc: Message attributes', (done) => {
   done();
 });
 
+test('DBC_template.dbc: Message attributes 2', (done) => {
+  const dbc = new Dbc();
+  const fileContent = dbcReader('src/__tests__/testFiles/DBC_template.dbc');
+  const data = dbc.load(fileContent);
+  const attributes: Attributes = new Map();
+  const attribute: Attribute = {
+    name: 'BOStringAttribute',
+    type: 'Message',
+    dataType: 'STRING',
+    options: null,
+    defaultValue: 'String',
+    value: 'MessageAttribute2',
+    min: null,
+    max: null,
+  };
+  attributes.set('BOStringAttribute', attribute);
+  expect(data.messages.get('CANMultiplexed')?.attributes).toEqual(attributes);
+  done();
+});
+
 test('DBC_template.dbc: Signal attributes', (done) => {
   const dbc = new Dbc();
   const fileContent = dbcReader('src/__tests__/testFiles/DBC_template.dbc');

--- a/src/__tests__/testFiles/DBC_template.dbc
+++ b/src/__tests__/testFiles/DBC_template.dbc
@@ -43,6 +43,7 @@ BA_ "FloatAttribute" 45.9;
 BA_ "BUIntAttribute" BU_ Node0 100;
 BA_ "BOStringAttribute" BO_ 1234 "MessageAttribute";
 BA_ "SGEnumAttribute" SG_ 1234 Signal0 2;
+BA_ "BOStringAttribute" BO_ 4321 "MessageAttribute2";
 
 VAL_TABLE_ Numbers 3 "Three" 2 "Two" 1 "One" 0 "Zero";
 VAL_ 4321 Value0 2 "Value2" 1 "Value1" 0 "Value0";

--- a/src/parser/dbcParser.ts
+++ b/src/parser/dbcParser.ts
@@ -461,48 +461,50 @@ export default class DbcParser extends Parser {
   }
 
   private addAttributeValue(dbc: DbcData, data: AttributeValue) {
-    const attr = dbc.attributes.get(data.name);
-    if (attr) {
-      attr.value = data.value;
-      const msgName = this.getMessageNameFromId(dbc, data.id);
-      switch (data.type) {
-        // Add existing attribute to proper type
-        case 'Signal':
-          if (msgName) {
-            const msg = dbc.messages.get(msgName);
-            if (msg) {
-              const signal = msg.signals.get(data.signal);
-              if (signal) {
-                signal.attributes.set(attr.name, attr);
-              }
+    if (!dbc.attributes.has(data.name)) 
+      return;
+    const attr = Object.assign({}, dbc.attributes.get(data.name), {value: data.value});
+    
+    attr.value = data.value;
+    const msgName = this.getMessageNameFromId(dbc, data.id);
+    switch (data.type) {
+      // Add existing attribute to proper type
+      case 'Signal':
+        if (msgName) {
+          const msg = dbc.messages.get(msgName);
+          if (msg) {
+            const signal = msg.signals.get(data.signal);
+            if (signal) {
+              signal.attributes.set(attr.name, attr);
             }
           }
-          break;
-        case 'Message':
-          if (msgName) {
-            const msg = dbc.messages.get(msgName);
-            if (msg) {
-              msg.attributes.set(attr.name, attr);
-            }
+        }
+        break;
+      case 'Message':
+        if (msgName) {
+          const msg = dbc.messages.get(msgName);
+          if (msg) {
+            msg.attributes.set(attr.name, attr);
           }
-          break;
-        case 'Node':
-          const node = dbc.nodes.get(data.node);
-          if (node) {
-            node.attributes.set(attr.name, attr);
-          }
-          break;
-        case 'Global':
-          break;
-        case 'EnvironmentVariable':
-          const ev = dbc.environmentVariables.get(data.node);
-          if (ev) {
-            ev.attributes.set(attr.name, attr);
-          }
-          break;
-        default:
-          break;
-      }
+        }
+        break;
+      case 'Node':
+        const node = dbc.nodes.get(data.node);
+        if (node) {
+          node.attributes.set(attr.name, attr);
+        }
+        break;
+      case 'Global':
+        dbc.attributes.set(data.name, attr);
+        break;
+      case 'EnvironmentVariable':
+        const ev = dbc.environmentVariables.get(data.node);
+        if (ev) {
+          ev.attributes.set(attr.name, attr);
+        }
+        break;
+      default:
+        break;
     }
   }
 


### PR DESCRIPTION
Pull request to solve [prevent setting attributes by reference](https://github.com/bit-dream/candied/issues/48)
DBC parsing issue: All messages with different DBC attributes with the same name, but different values have the same attribute value (the last one declared in the dbc file).
Reason: DBC attributes are copied by reference.

Added corresponding test.

