### PR TITLE
Fixed probably deprecated example in "load dbc" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,20 @@ import {Dbc} from 'candied';
 const dbc = new Dbc();
 
 // Node based file loading
-import dbcReader from "dbc-can/lib/filesystem/DbcReader"
+import dbcReader from "candied/lib/filesystem/DbcReader"
 const fileContent = dbcReader('example.dbc');
 const data = dbc.load(fileContent);
 
 // Browser based file loading
-import {dbcReader} from "dbc-can/lib/filesystem/DbcWebFs";
+import {dbcReader} from "candied/lib/filesystem/DbcWebFs";
 // dbcReader expects a file based/blob based input
 // interface File extends Blob
 const fileContent = dbcReader(file);
-const data = dbc.load(fileContent);
+dbcReader(file, (fileContent) => {
+    const data = dbc.load(fileContent);
+
+    // your code
+});
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ const data = dbc.load(fileContent);
 import {dbcReader} from "candied/lib/filesystem/DbcWebFs";
 // dbcReader expects a file based/blob based input
 // interface File extends Blob
-const fileContent = dbcReader(file);
 dbcReader(file, (fileContent) => {
     const data = dbc.load(fileContent);
 


### PR DESCRIPTION
updated import statements to new repo name
added onLoad callback function to dbcReader call for web based file reading as previous example uses a void return value and does not work